### PR TITLE
Remove placeholders and make paths configurable

### DIFF
--- a/RhinoSdRenderer_skeleton/.github/workflows/build.yml
+++ b/RhinoSdRenderer_skeleton/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.0.x'
-      - name: Build plugin
+      - name: Build and package
+        shell: pwsh
         run: |
-          dotnet build plugin/RhinoSdRenderer.csproj -c Release
-      # TODO: Add signing & .rhi packaging
+          pwsh scripts/build_plugin.ps1 -Configuration Release

--- a/RhinoSdRenderer_skeleton/plugin/PlugIn/RhinoSdRendererPlugIn.cs
+++ b/RhinoSdRenderer_skeleton/plugin/PlugIn/RhinoSdRendererPlugIn.cs
@@ -22,7 +22,8 @@ namespace RhinoSdRenderer
             try
             {
                 // Initialise pythonnet runtime & append python path
-                Runtime.PythonDLL = "python310.dll";         // TODO: make configurable
+                string pyDll = Environment.GetEnvironmentVariable("PYTHON_DLL") ?? "python310.dll";
+                Runtime.PythonDLL = pyDll;
                 PythonEngine.Initialize();
                 using (Py.GIL())
                 {
@@ -67,7 +68,9 @@ namespace RhinoSdRenderer
             {
                 dynamic bridge = Py.Import("main");  // python/main.py
                 var pyBytes    = new PyBytes(pngBytes);
-                dynamic pyImg  = bridge.render_image(pyBytes, "brutalist atrium"); // placeholder prompt
+                string prompt  = Environment.GetEnvironmentVariable("SD_PROMPT")
+                                 ?? "A photorealistic render";
+                dynamic pyImg  = bridge.render_image(pyBytes, prompt);
                 resultBmp      = (Bitmap)pyImg.AsManagedObject(typeof(Bitmap));
             }
 

--- a/RhinoSdRenderer_skeleton/python/main.py
+++ b/RhinoSdRenderer_skeleton/python/main.py
@@ -10,7 +10,7 @@ We return:
 import io, os, torch, numpy as np
 from PIL import Image
 from diffusers import StableDiffusionControlNetPipeline, ControlNetModel
-from controlnet_aux import OpenposeDetector, CannyDetector
+from controlnet_aux import CannyDetector
 
 # --- lazy global initialisation ---
 pipe = None
@@ -18,7 +18,7 @@ def _init():
     global pipe, canny
     if pipe is not None:
         return
-    model_path   = os.getenv("SDXL_PATH",   "../models/sd35_medium")   # TODO: CLI/env override
+    model_path   = os.getenv("SDXL_PATH",   "../models/sd35_medium")
     control_path = os.getenv("CANNY_PATH",  "../models/canny_cn")
     controlnet   = ControlNetModel.from_pretrained(control_path, torch_dtype=torch.float16)
     pipe         = StableDiffusionControlNetPipeline.from_pretrained(
@@ -49,3 +49,16 @@ def render_image(png_bytes: bytes, prompt: str):
     ms = SD.Imaging.MemoryStream()
     out.save(ms, format="PNG")
     return SD.Bitmap(ms)
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Render an image using the SD pipeline")
+    parser.add_argument("input", help="Input PNG file")
+    parser.add_argument("--prompt", required=True, help="Text prompt")
+    parser.add_argument("-o", "--output", default="out.png", help="Output file")
+    args = parser.parse_args()
+
+    with open(args.input, "rb") as f:
+        bmp = render_image(f.read(), args.prompt)
+    bmp.Save(args.output)

--- a/RhinoSdRenderer_skeleton/scripts/build_plugin.ps1
+++ b/RhinoSdRenderer_skeleton/scripts/build_plugin.ps1
@@ -14,7 +14,10 @@ if (!(Test-Path $dist)) { New-Item $dist -ItemType Directory | Out-Null }
 Get-ChildItem plugin/bin/$Configuration/net7.0-windows/*.rhp | Copy-Item -Destination $dist -Force
 Get-ChildItem plugin/bin/$Configuration/net7.0-windows/*.dll | Copy-Item -Destination $dist -Force
 
-Write-Host "📦 Packing .rhi … (placeholder – implement Rhino RHI packaging here)"
-# TODO: call Rhino Installer Engine CLI or zip as .rhi
+Write-Host "📦 Packing .rhi …"
+$rhi = Join-Path $dist 'RhinoSdRenderer.rhi'
+if (Test-Path $rhi) { Remove-Item $rhi }
+Compress-Archive -Path (Join-Path $dist '*') -DestinationPath $rhi
+
 
 Write-Host "✅ Done.  Output in dist/"


### PR DESCRIPTION
## Summary
- allow `PYTHON_DLL` and `SD_PROMPT` environment variable overrides
- add RHI packaging to build script
- expose a debug CLI in the python bridge
- use packaging script in CI workflow

## Testing
- `python -m py_compile RhinoSdRenderer_skeleton/python/main.py RhinoSdRenderer_skeleton/scripts/download_models.py`
- `dotnet build RhinoSdRenderer_skeleton/plugin/RhinoSdRenderer.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d0ef71a883329657eeeff1678963