### PR TITLE
Add LumenIO hub and web client skeleton with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install Node deps
+        working-directory: LumenIO/clients/web
+        run: npm ci
+      - name: Run vitest
+        working-directory: LumenIO/clients/web
+        run: npm test
+      - name: Run playwright
+        working-directory: LumenIO/clients/web
+        run: npx playwright install --with-deps && npx playwright test
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Python deps
+        working-directory: LumenIO/hub
+        run: pip install -r requirements.txt
+      - name: Run pytest
+        working-directory: LumenIO/hub
+        run: pytest

--- a/LumenIO/bootstrap.xml
+++ b/LumenIO/bootstrap.xml
@@ -1,0 +1,40 @@
+<project>
+  <name>LumenIO</name>
+  <description>Gesture-first multi-device programming interface (PC, Mobile, Projector, Standalone, Wearables).</description>
+  <authors>
+    <author role="cipher">LLM/NN Prompt Engineer</author>
+    <author role="forge">Mech/Electrical/Industrial Engineer</author>
+  </authors>
+  <repository>https://github.com/testingground/LumenIO</repository>
+  <modules>
+    <module>hub</module>
+    <module>clients</module>
+    <module>adapters</module>
+    <module>agents</module>
+    <module>calibration</module>
+  </modules>
+  <dependencies>
+    <dep>Python 3.11+</dep>
+    <dep>FastAPI + aiortc</dep>
+    <dep>OpenCV</dep>
+    <dep>MediaPipe/TFLite</dep>
+    <dep>Blender Python API</dep>
+    <dep>WebRTC/WebGPU/WebXR</dep>
+    <dep>Node 20</dep>
+    <dep>Vite/Vitest/Playwright</dep>
+  </dependencies>
+  <testing>
+    <python>pytest httpx jsonschema coverage</python>
+    <node>vitest playwright coverage</node>
+  </testing>
+  <ci>
+    <service>GitHub Actions</service>
+  </ci>
+  <handoff>
+    <directory>LumenIO</directory>
+    <file>bootstrap.xml</file>
+  </handoff>
+  <preferences>
+    <codex_mode>CODE_FIRST_MINIMAL</codex_mode>
+  </preferences>
+</project>

--- a/LumenIO/clients/web/e2e/app.spec.js
+++ b/LumenIO/clients/web/e2e/app.spec.js
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('renders greeting', async ({ page }) => {
+  await page.setContent('<div id="app">Hello LumenIO</div>');
+  await expect(page.locator('#app')).toHaveText('Hello LumenIO');
+});

--- a/LumenIO/clients/web/index.html
+++ b/LumenIO/clients/web/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>LumenIO</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/LumenIO/clients/web/package.json
+++ b/LumenIO/clients/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "lumenio-web-client",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.0",
+    "vite": "^5.2.0",
+    "vitest": "^1.5.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/LumenIO/clients/web/src/main.js
+++ b/LumenIO/clients/web/src/main.js
@@ -1,0 +1,5 @@
+export function greet(name) {
+  return `Hello ${name}`;
+}
+
+document.getElementById('app').textContent = greet('LumenIO');

--- a/LumenIO/clients/web/test/greet.test.js
+++ b/LumenIO/clients/web/test/greet.test.js
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { greet } from '../src/main.js';
+
+describe('greet', () => {
+  it('greets by name', () => {
+    expect(greet('World')).toBe('Hello World');
+  });
+});

--- a/LumenIO/hub/__init__.py
+++ b/LumenIO/hub/__init__.py
@@ -1,0 +1,1 @@
+"""Hub package."""

--- a/LumenIO/hub/main.py
+++ b/LumenIO/hub/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/ping')
+async def ping():
+  return {'msg': 'pong'}

--- a/LumenIO/hub/requirements.txt
+++ b/LumenIO/hub/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+jsonschema

--- a/LumenIO/hub/tests/test_ping.py
+++ b/LumenIO/hub/tests/test_ping.py
@@ -1,0 +1,10 @@
+import pytest
+from httpx import AsyncClient
+from main import app
+
+@pytest.mark.asyncio
+async def test_ping():
+  async with AsyncClient(app=app, base_url='http://test') as ac:
+    res = await ac.get('/ping')
+  assert res.status_code == 200
+  assert res.json() == {'msg': 'pong'}

--- a/LumenIO/hub/tests/test_schema.py
+++ b/LumenIO/hub/tests/test_schema.py
@@ -1,0 +1,9 @@
+import json
+from jsonschema import validate
+from pathlib import Path
+
+def test_gesture_schema():
+  schema_path = Path(__file__).resolve().parent.parent.parent / 'schemas' / 'gesture.json'
+  schema = json.loads(schema_path.read_text())
+  sample = {'type': 'wave', 'confidence': 0.9}
+  validate(instance=sample, schema=schema)

--- a/LumenIO/schemas/gesture.json
+++ b/LumenIO/schemas/gesture.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Gesture",
+  "type": "object",
+  "properties": {
+    "type": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  },
+  "required": ["type", "confidence"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- scaffold LumenIO web client with Vite/Vitest/Playwright setup
- introduce FastAPI hub with basic ping endpoint and JSON schema
- configure GitHub Actions CI for Node and Python tests

## Testing
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: playwright: not found)*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68b2515d54a883329b34a5aa57496bef