### PR TITLE
chore: scaffold separated Playwright E2E packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd core && npm test
+
+  variants:
+    needs: core
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [ pc, mobile, pcproj, mobileproj, standalone, wearables ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd variants/${{ matrix.variant }} && npm test
+
+  e2e:
+    needs: variants
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ e2e-pc, e2e-mobile, e2e-pcproj, e2e-mobileproj, e2e-standalone, e2e-wearables ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd e2e/${{ matrix.package }} && npm test

--- a/LumenIO/bootstrap.xml
+++ b/LumenIO/bootstrap.xml
@@ -24,6 +24,23 @@
     <dep>WebRTC/WebGPU/WebXR</dep>
   </dependencies>
 
+  <packages>
+    <package name="core"/>
+    <package name="pc" depends="core"/>
+    <package name="mobile" depends="core"/>
+    <package name="pcproj" depends="core"/>
+    <package name="mobileproj" depends="core"/>
+    <package name="standalone" depends="core"/>
+    <package name="wearables" depends="core"/>
+
+    <package name="e2e-pc" depends="pc"/>
+    <package name="e2e-mobile" depends="mobile"/>
+    <package name="e2e-pcproj" depends="pcproj"/>
+    <package name="e2e-mobileproj" depends="mobileproj"/>
+    <package name="e2e-standalone" depends="standalone"/>
+    <package name="e2e-wearables" depends="wearables"/>
+  </packages>
+
   <handoff>
     <directory>LumenIO</directory>
     <file>bootstrap.xml</file>

--- a/e2e/e2e-mobile/package.json
+++ b/e2e/e2e-mobile/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-mobile",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/e2e/e2e-mobile/playwright.config.js
+++ b/e2e/e2e-mobile/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Pixel 5', use: { ...devices['Pixel 5'] } }
+  ]
+});

--- a/e2e/e2e-mobile/tests/smoke.spec.ts
+++ b/e2e/e2e-mobile/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/e2e/e2e-mobileproj/package.json
+++ b/e2e/e2e-mobileproj/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-mobileproj",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/e2e/e2e-mobileproj/playwright.config.js
+++ b/e2e/e2e-mobileproj/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Pixel 5', use: { ...devices['Pixel 5'] } }
+  ]
+});

--- a/e2e/e2e-mobileproj/tests/smoke.spec.ts
+++ b/e2e/e2e-mobileproj/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/e2e/e2e-pc/package.json
+++ b/e2e/e2e-pc/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-pc",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/e2e/e2e-pc/playwright.config.js
+++ b/e2e/e2e-pc/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } }
+  ]
+});

--- a/e2e/e2e-pc/tests/smoke.spec.ts
+++ b/e2e/e2e-pc/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/e2e/e2e-pcproj/package.json
+++ b/e2e/e2e-pcproj/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-pcproj",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/e2e/e2e-pcproj/playwright.config.js
+++ b/e2e/e2e-pcproj/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } }
+  ]
+});

--- a/e2e/e2e-pcproj/tests/smoke.spec.ts
+++ b/e2e/e2e-pcproj/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/e2e/e2e-standalone/package.json
+++ b/e2e/e2e-standalone/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-standalone",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/e2e/e2e-standalone/playwright.config.js
+++ b/e2e/e2e-standalone/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } }
+  ]
+});

--- a/e2e/e2e-standalone/tests/smoke.spec.ts
+++ b/e2e/e2e-standalone/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/e2e/e2e-wearables/package.json
+++ b/e2e/e2e-wearables/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-wearables",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/e2e/e2e-wearables/playwright.config.js
+++ b/e2e/e2e-wearables/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Pixel 5', use: { ...devices['Pixel 5'] } }
+  ]
+});

--- a/e2e/e2e-wearables/tests/smoke.spec.ts
+++ b/e2e/e2e-wearables/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/scripts/scaffold-mobile.sh
+++ b/scripts/scaffold-mobile.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="mobile"
+DIR="variants/mobile"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/mobile",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/scripts/scaffold-mobileproj.sh
+++ b/scripts/scaffold-mobileproj.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="mobileproj"
+DIR="variants/mobileproj"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/mobileproj",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/scripts/scaffold-pc.sh
+++ b/scripts/scaffold-pc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="pc"
+DIR="variants/pc"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/pc",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/scripts/scaffold-pcproj.sh
+++ b/scripts/scaffold-pcproj.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="pcproj"
+DIR="variants/pcproj"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/pcproj",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/scripts/scaffold-standalone.sh
+++ b/scripts/scaffold-standalone.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="standalone"
+DIR="variants/standalone"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/standalone",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/scripts/scaffold-wearables.sh
+++ b/scripts/scaffold-wearables.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="wearables"
+DIR="variants/wearables"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/wearables",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS


### PR DESCRIPTION
## Summary
- add six Playwright-based E2E packages (pc, mobile, pcproj, mobileproj, standalone, wearables)
- provide shell scripts to scaffold matching variant packages with Vitest tests
- wire up GitHub Actions matrix to run core, variant, and E2E tests sequentially
- expand bootstrap.xml to document package dependencies

## Testing
- `cd e2e/e2e-pc && npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b26d15414883328c504e8df4b0c583