### PR TITLE
Install dependencies for Playwright E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd LumenIO/core && npm test
+
+  variants:
+    needs: core
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [ pc, mobile, pcproj, mobileproj, standalone, wearables ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd LumenIO/variants/${{ matrix.variant }} && npm test
+
+  e2e:
+    needs: variants
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ e2e-pc, e2e-mobile, e2e-pcproj, e2e-mobileproj, e2e-standalone, e2e-wearables ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: |
+          cd LumenIO/e2e/${{ matrix.package }}
+          npm install
+          npx playwright install
+          npm test

--- a/LumenIO/bootstrap.xml
+++ b/LumenIO/bootstrap.xml
@@ -24,6 +24,23 @@
     <dep>WebRTC/WebGPU/WebXR</dep>
   </dependencies>
 
+  <packages>
+    <package name="core"/>
+    <package name="pc" depends="core"/>
+    <package name="mobile" depends="core"/>
+    <package name="pcproj" depends="core"/>
+    <package name="mobileproj" depends="core"/>
+    <package name="standalone" depends="core"/>
+    <package name="wearables" depends="core"/>
+
+    <package name="e2e-pc" depends="pc"/>
+    <package name="e2e-mobile" depends="mobile"/>
+    <package name="e2e-pcproj" depends="pcproj"/>
+    <package name="e2e-mobileproj" depends="mobileproj"/>
+    <package name="e2e-standalone" depends="standalone"/>
+    <package name="e2e-wearables" depends="wearables"/>
+  </packages>
+
   <handoff>
     <directory>LumenIO</directory>
     <file>bootstrap.xml</file>

--- a/LumenIO/core/package.json
+++ b/LumenIO/core/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/core",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/core/tests/sample.spec.ts
+++ b/LumenIO/core/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/LumenIO/e2e/e2e-mobile/package.json
+++ b/LumenIO/e2e/e2e-mobile/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-mobile",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/LumenIO/e2e/e2e-mobile/playwright.config.js
+++ b/LumenIO/e2e/e2e-mobile/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Pixel 5', use: { ...devices['Pixel 5'] } }
+  ]
+});

--- a/LumenIO/e2e/e2e-mobile/tests/smoke.spec.ts
+++ b/LumenIO/e2e/e2e-mobile/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/LumenIO/e2e/e2e-mobileproj/package.json
+++ b/LumenIO/e2e/e2e-mobileproj/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-mobileproj",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/LumenIO/e2e/e2e-mobileproj/playwright.config.js
+++ b/LumenIO/e2e/e2e-mobileproj/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Pixel 5', use: { ...devices['Pixel 5'] } }
+  ]
+});

--- a/LumenIO/e2e/e2e-mobileproj/tests/smoke.spec.ts
+++ b/LumenIO/e2e/e2e-mobileproj/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/LumenIO/e2e/e2e-pc/package.json
+++ b/LumenIO/e2e/e2e-pc/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-pc",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/LumenIO/e2e/e2e-pc/playwright.config.js
+++ b/LumenIO/e2e/e2e-pc/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } }
+  ]
+});

--- a/LumenIO/e2e/e2e-pc/tests/smoke.spec.ts
+++ b/LumenIO/e2e/e2e-pc/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/LumenIO/e2e/e2e-pcproj/package.json
+++ b/LumenIO/e2e/e2e-pcproj/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-pcproj",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/LumenIO/e2e/e2e-pcproj/playwright.config.js
+++ b/LumenIO/e2e/e2e-pcproj/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } }
+  ]
+});

--- a/LumenIO/e2e/e2e-pcproj/tests/smoke.spec.ts
+++ b/LumenIO/e2e/e2e-pcproj/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/LumenIO/e2e/e2e-standalone/package.json
+++ b/LumenIO/e2e/e2e-standalone/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-standalone",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/LumenIO/e2e/e2e-standalone/playwright.config.js
+++ b/LumenIO/e2e/e2e-standalone/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Desktop Chrome', use: { ...devices['Desktop Chrome'] } }
+  ]
+});

--- a/LumenIO/e2e/e2e-standalone/tests/smoke.spec.ts
+++ b/LumenIO/e2e/e2e-standalone/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/LumenIO/e2e/e2e-wearables/package.json
+++ b/LumenIO/e2e/e2e-wearables/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/e2e-wearables",
+  "private": true,
+  "devDependencies": {
+    "@playwright/test": "^1.41.1"
+  },
+  "scripts": {
+    "test": "playwright test"
+  }
+}

--- a/LumenIO/e2e/e2e-wearables/playwright.config.js
+++ b/LumenIO/e2e/e2e-wearables/playwright.config.js
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    { name: 'Pixel 5', use: { ...devices['Pixel 5'] } }
+  ]
+});

--- a/LumenIO/e2e/e2e-wearables/tests/smoke.spec.ts
+++ b/LumenIO/e2e/e2e-wearables/tests/smoke.spec.ts
@@ -1,0 +1,5 @@
+import { test, expect } from '@playwright/test';
+
+test('smoke', async () => {
+  expect(true).toBeTruthy();
+});

--- a/LumenIO/scripts/scaffold-mobile.sh
+++ b/LumenIO/scripts/scaffold-mobile.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="mobile"
+DIR="LumenIO/variants/mobile"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/mobile",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/LumenIO/scripts/scaffold-mobileproj.sh
+++ b/LumenIO/scripts/scaffold-mobileproj.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="mobileproj"
+DIR="LumenIO/variants/mobileproj"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/mobileproj",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/LumenIO/scripts/scaffold-pc.sh
+++ b/LumenIO/scripts/scaffold-pc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="pc"
+DIR="LumenIO/variants/pc"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/pc",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/LumenIO/scripts/scaffold-pcproj.sh
+++ b/LumenIO/scripts/scaffold-pcproj.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="pcproj"
+DIR="LumenIO/variants/pcproj"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/pcproj",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/LumenIO/scripts/scaffold-standalone.sh
+++ b/LumenIO/scripts/scaffold-standalone.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="standalone"
+DIR="LumenIO/variants/standalone"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/standalone",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/LumenIO/scripts/scaffold-wearables.sh
+++ b/LumenIO/scripts/scaffold-wearables.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+NAME="wearables"
+DIR="LumenIO/variants/wearables"
+mkdir -p "$DIR/tests"
+cat > "$DIR/package.json" <<'JSON'
+{
+  "name": "@lumenio/wearables",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}
+JSON
+cat > "$DIR/tests/sample.spec.ts" <<'TS'
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});
+TS

--- a/LumenIO/variants/mobile/package.json
+++ b/LumenIO/variants/mobile/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/mobile",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/variants/mobile/tests/sample.spec.ts
+++ b/LumenIO/variants/mobile/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/LumenIO/variants/mobileproj/package.json
+++ b/LumenIO/variants/mobileproj/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/mobileproj",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/variants/mobileproj/tests/sample.spec.ts
+++ b/LumenIO/variants/mobileproj/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/LumenIO/variants/pc/package.json
+++ b/LumenIO/variants/pc/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/pc",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/variants/pc/tests/sample.spec.ts
+++ b/LumenIO/variants/pc/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/LumenIO/variants/pcproj/package.json
+++ b/LumenIO/variants/pcproj/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/pcproj",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/variants/pcproj/tests/sample.spec.ts
+++ b/LumenIO/variants/pcproj/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/LumenIO/variants/standalone/package.json
+++ b/LumenIO/variants/standalone/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/standalone",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/variants/standalone/tests/sample.spec.ts
+++ b/LumenIO/variants/standalone/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/LumenIO/variants/wearables/package.json
+++ b/LumenIO/variants/wearables/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lumenio/wearables",
+  "private": true,
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
+}

--- a/LumenIO/variants/wearables/tests/sample.spec.ts
+++ b/LumenIO/variants/wearables/tests/sample.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('sample', () => {
+  it('works', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure CI installs dependencies for each Playwright E2E package before running tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npx playwright install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b26d15414883328c504e8df4b0c583